### PR TITLE
refactor the orders to use class references because a lot of things c…

### DIFF
--- a/EngineYardTests/OrderBookTests.swift
+++ b/EngineYardTests/OrderBookTests.swift
@@ -18,7 +18,8 @@ class OrderBookTests: XCTestCase {
 
     func testOrderBookOrdersIsEmpty() {
         let orderBook = OrderBook.init(capacity: 3)
-        XCTAssertTrue(((orderBook.orders?.isEmpty) != nil))
+        XCTAssertTrue(orderBook.isEmpty)
+        XCTAssertTrue(orderBook.orders.count == 0)
     }
 
     func testOrderBookHasSingleOrder() {
@@ -28,13 +29,7 @@ class OrderBookTests: XCTestCase {
             try orderBook.add(.existingOrder)
         )
         XCTAssertNotNil(orderBook.orders)
-
-        guard let orders = orderBook.orders else {
-            XCTFail("Orders do not exist")
-            return
-        }
-
-        XCTAssertTrue(orders.count == 1)
+        XCTAssertTrue(orderBook.count == 1)
     }
 
     func testDidAddMixedOrderTypesToOrderBook() {
@@ -53,18 +48,14 @@ class OrderBookTests: XCTestCase {
             try orderBook.add(.completedOrder)
         )
 
-        guard let orders = orderBook.orders else {
-            XCTFail("No orders")
-            return
-        }
+        XCTAssertFalse(orderBook.orders.isEmpty)
+        XCTAssertTrue(orderBook.count == 3)
 
-        XCTAssertTrue(orders.count == 3)
-
-        let totalExistingOrders = orders.filter { (order: Order) -> Bool in
+        let totalExistingOrders = orderBook.orders.filter { (order: Order) -> Bool in
             return (order.state == .existingOrder)
         }.count
 
-        let totalCompletedOrders = orders.filter { (order: Order) -> Bool in
+        let totalCompletedOrders = orderBook.orders.filter { (order: Order) -> Bool in
             return (order.state == .completedOrder)
         }.count
 
@@ -93,12 +84,7 @@ class OrderBookTests: XCTestCase {
             try orderBook.add(.completedOrder)
         )
 
-        guard let orders = orderBook.orders else {
-            XCTFail("Orders do not exist")
-            return
-        }
-
-        XCTAssertTrue(orders.count == capacity)
+        XCTAssertTrue(orderBook.count == capacity)
         XCTAssertTrue(orderBook.isFull)
     }
 
@@ -110,21 +96,16 @@ class OrderBookTests: XCTestCase {
             try orderBook.add(.existingOrder)
         )
 
-        guard let orders = orderBook.orders else {
-            XCTFail("Orders do not exist")
-            return
-        }
+        XCTAssertTrue(orderBook.count == 1)
 
-        XCTAssertTrue(orders.count == 1)
-
-        guard var firstOrder = orders.first else {
+        guard let firstOrder = orderBook.orders.first else {
             XCTFail("No first order found")
             return
         }
         XCTAssertTrue(firstOrder.state == .existingOrder)
 
         XCTAssertNoThrow(
-            try orderBook.transfer(order: &firstOrder, to: .completedOrder)
+            try orderBook.transfer(order: firstOrder, to: .completedOrder)
         )
 
         XCTAssertTrue(firstOrder.state == .completedOrder)
@@ -138,12 +119,10 @@ class OrderBookTests: XCTestCase {
             try orderBook.add(.existingOrder)
         )
 
-        XCTAssertNotNil(orderBook.orders)
-        guard let orders = orderBook.orders else {
-            XCTFail("No orders defined")
-            return
-        }
-        guard var firstOrder = orders.first else {
+        XCTAssertTrue(!orderBook.isEmpty)
+        XCTAssertTrue(orderBook.orders.count == 1)
+
+        guard let firstOrder = orderBook.orders.first else {
             XCTFail("No first order defined")
             return
         }
@@ -152,7 +131,7 @@ class OrderBookTests: XCTestCase {
         )
         XCTAssertTrue(firstOrder.value == 6)
         XCTAssertNoThrow(
-            try orderBook.reduce(order: &firstOrder, by: 1)
+            try orderBook.reduce(order: firstOrder, by: 1)
         )
         XCTAssertTrue(firstOrder.value == 5, "Expected: 5, Found: \(firstOrder.value)")
     }
@@ -162,13 +141,15 @@ class OrderBookTests: XCTestCase {
         let capacity = 3
         let orderBook = OrderBook.init(capacity: capacity)
 
-        XCTAssertTrue(orderBook.orders?.count == 0)
+        XCTAssertTrue(orderBook.isEmpty)
+        XCTAssertTrue(orderBook.orders.count == 0)
 
         XCTAssertNoThrow(
             try orderBook.add(.initialOrder)
         )
 
-        XCTAssertTrue(orderBook.orders?.count == 1)
+        XCTAssertFalse(orderBook.isEmpty)
+        XCTAssertTrue(orderBook.orders.count == 1)
 
         // check against initial orders
         let initialOrders = orderBook.filterOrders(for: .initialOrder)
@@ -190,7 +171,7 @@ class OrderBookTests: XCTestCase {
         for _ in 0...(capacity - 1) {
             XCTAssertNoThrow( try orderBook.add(.completedOrder) )
         }
-        XCTAssertTrue(orderBook.orders?.count == capacity)
+        XCTAssertTrue(orderBook.orders.count == capacity)
         XCTAssertTrue(orderBook.filterOrders(for: .completedOrder)?.count == 3)
 
     }

--- a/EngineYardTests/OrderTests.swift
+++ b/EngineYardTests/OrderTests.swift
@@ -30,7 +30,7 @@ class OrderTests: XCTestCase {
     }
 
     func testCannotReduceValueOfCompletedOrder() {
-        var order = Order.init(.completedOrder)
+        let order = Order.init(.completedOrder)
 
         XCTAssertThrowsError(try order.reduceValue(by: 1)) { error in
            XCTAssertEqual(error as! OrderError, OrderError.orderCannotBe(.completedOrder))
@@ -39,14 +39,14 @@ class OrderTests: XCTestCase {
     }
 
     func testCannotReduceValueOfInitialOrder() {
-        var order = Order.init(.initialOrder)
+        let order = Order.init(.initialOrder)
         XCTAssertThrowsError(try order.reduceValue(by: 1)) { error in
            XCTAssertEqual(error as! OrderError, OrderError.orderCannotBe(.initialOrder))
         }
     }
 
     func testCanReduceValueOfExistingOrder() {
-        var order = Order.init(.existingOrder)
+        let order = Order.init(.existingOrder)
         let orderValue = (order.value - 1)
 
         XCTAssertNoThrow(
@@ -57,7 +57,7 @@ class OrderTests: XCTestCase {
     }
 
     func testExistingOrderDidReduceBy1() {
-        var order = Order.init(.existingOrder)
+        let order = Order.init(.existingOrder)
         XCTAssertNoThrow(
             try order.setValue(6)
         )
@@ -70,7 +70,7 @@ class OrderTests: XCTestCase {
     }
 
     func testExisitingOrderDidReduceBy5() {
-        var order = Order.init(.existingOrder)
+        let order = Order.init(.existingOrder)
         XCTAssertNoThrow(
             try order.setValue(6)
         )
@@ -82,7 +82,7 @@ class OrderTests: XCTestCase {
     }
 
     func testExistingOrderDidReduceToZero() {
-        var order = Order.init(.existingOrder)
+        let order = Order.init(.existingOrder)
         XCTAssertNoThrow(
             try order.setValue(2)
         )
@@ -100,7 +100,7 @@ class OrderTests: XCTestCase {
     }
 
     func testOrderCannotGoNegative() {
-        var order = Order.init(.existingOrder)
+        let order = Order.init(.existingOrder)
         XCTAssertNoThrow(
             try order.setValue(0)
         )

--- a/Shared/Locomotive.swift
+++ b/Shared/Locomotive.swift
@@ -66,13 +66,10 @@ extension Locomotive {
         self.state = to
     }
 
-    func setOrders(orders: [Order]) {
-        guard !orders.isEmpty else {
+    internal func setOrders(from orderBook: OrderBook) {
+        guard ((!orderBook.isEmpty) && (orderBook.orders.count > 0 && orderBook.orders.count <= self.orderCapacity)) else {
             return
         }
-        guard (orders.capacity == self.orderCapacity) else {
-            return
-        }
-        self.orders = orders
+        self.orders = orderBook.orders
     }
 }

--- a/Shared/MarketDemand.swift
+++ b/Shared/MarketDemand.swift
@@ -264,7 +264,8 @@ extension MarketDemand {
         locos.forEach { (locomotive) in
             print ("Locomotive: \(locomotive.name), \(locomotive.color), \(locomotive.orders)")
 
-            let orderBook = OrderBook.init(capacity: locomotive.orderCapacity, orders: locomotive.orders)
+            /*
+            let orderBook = OrderBook.init(capacity: locomotive.orderCapacity)
 
             if (!orderBook.isFull) {
                 do {
@@ -272,15 +273,12 @@ extension MarketDemand {
                 } catch {
                     print ("error -- \(error as Any)")
                 }
-                guard let orderBookOrders = orderBook.orders else {
-                    print ("Can't obtain orderbook proxy orders")
-                    return
-                }
-                locomotive.setOrders(orders: orderBookOrders)
+                locomotive.setOrders(from: orderBook)
             }
             else {
                 print("Locomotive is full")
             }
+             */
 
         }
 

--- a/Shared/Order.swift
+++ b/Shared/Order.swift
@@ -18,7 +18,7 @@ enum OrderError: Error, Equatable {
     case orderCannotBe(_ state: Order.State)
 }
 
-struct Order: Identifiable {
+class Order: Identifiable {
     let id: UUID = UUID()
 
     enum State: Int, CaseIterable {
@@ -41,10 +41,10 @@ extension Order: Equatable {
 }
 
 extension Order {
-    mutating func setState(to state: Order.State) {
+    func setState(to state: Order.State) {
         self.state = state
     }
-    internal mutating func setValue(_ value: Int) throws {
+    func setValue(_ value: Int) throws {
         guard value >= 0 else {
             throw IntError.cannotBeNegative
         }
@@ -54,7 +54,7 @@ extension Order {
 
 extension Order {
     // Only existing orders can be reduced in value
-    mutating func reduceValue(by amount: Int) throws {
+    func reduceValue(by amount: Int) throws {
         guard (amount >= 0) else {
             throw IntError.cannotBeNegative
         }
@@ -68,7 +68,7 @@ extension Order {
         willReduceValue(by: amount)
     }
 
-    private mutating func willReduceValue(by amount: Int) {
+    private func willReduceValue(by amount: Int) {
         self.value -= amount
     }
 }


### PR DESCRIPTION
refactor the orderbook to handle class references
refactor the ordertests and orderbook tests to handle class references
fix a bug with `isFull`